### PR TITLE
json format is only supported for some models

### DIFF
--- a/src/app/page.md
+++ b/src/app/page.md
@@ -54,7 +54,7 @@ Then, we can create a classifier instance and fit it using conventional scikit-l
 ```python
 from skllm.models.gpt.classification.zero_shot import ZeroShotGPTClassifier
 
-clf = ZeroShotGPTClassifier(model="gpt-4")
+clf = ZeroShotGPTClassifier(model="gpt-4-turbo")
 clf.fit(X,y)
 clf.predict(X)
 ```


### PR DESCRIPTION
As per Openai:

To prevent these errors and improve model performance, when using gpt-4o, gpt-4-turbo, or gpt-3.5-turbo, you can set [response_format](https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format) to { "type": "json_object" } to enable JSON mode. When JSON mode is enabled, the model is constrained to only generate strings that parse into valid JSON object.

Currently GPTClassifierMixin overrides `_prefer_json_output = False` to `True` from GPTMixin.
On my end this leads to the following error when running the basic example:
~~~
RuntimeError: Could not complete the operation after 3 retries: `BadRequestError :: Error code: 400 - {'error': {'message': "Invalid parameter: 'response_format' of type 'json_object' is not supported with this model.", 'type': 'invalid_request_error', 'param': 'response_format', 'code': None}}`
~~~
